### PR TITLE
Real symbol if supported by the context

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,7 +1,7 @@
 import Symbolic from './symbolic.js';
 import { isFunction } from './types.js';
 
-const SYM = new Symbolic('listeners');
+const SYM = Symbolic('listeners');
 
 /**
  * Add a callback for the specified trigger.

--- a/src/factory.js
+++ b/src/factory.js
@@ -14,30 +14,32 @@ import { isObject, isString } from './types.js';
 import { on, off, trigger } from './events.js';
 import { has } from './proto.js';
 
-const FACTORY_SYM = new Symbolic('fsymbol');
+const FACTORY_SYM = Symbolic('fsymbol');
 
 /**
  * Symbol for Factory context.
  * @memberof Factory
  * @type {Symbolic}
  */
-export const CONTEXT_SYM = new Symbolic('context');
+export const CONTEXT_SYM = Symbolic('context');
 
 /**
  * Symbol for Factory configuration.
  * @memberof Factory
  * @type {Symbolic}
  */
-export const CONFIG_SYM = new Symbolic('config');
+export const CONFIG_SYM = Symbolic('config');
 
 /**
  * Symbol for Factory listeners.
  * @memberof Factory
  * @type {Symbolic}
  */
-export const LISTENERS_SYM = new Symbolic('listeners');
+export const LISTENERS_SYM = Symbolic('listeners');
 
 let context;
+
+const FACTORY_SYMBOLS = {};
 
 /**
  * Base Factory mixin.
@@ -55,9 +57,9 @@ export const FactoryMixin = (SuperClass) => class extends SuperClass {
      * @memberof Factory.BaseFactory
      */
     static get SYM() {
-        if (!this.hasOwnProperty(FACTORY_SYM.SYM)) {
-            let sym = new Symbolic(this.name);
-            sym.Ctr = this;
+        if (!this.hasOwnProperty(FACTORY_SYM)) {
+            let sym = Symbolic(this.name);
+            FACTORY_SYMBOLS[sym] = this;
             this[FACTORY_SYM] = sym;
         }
         return this[FACTORY_SYM];
@@ -303,8 +305,8 @@ export const InjectableMixin = (SuperClass) => class extends mix(SuperClass).wit
         super.initialize(...args);
         let ctx = this[CONTEXT_SYM];
         this.inject.forEach((Injector) => {
-            if (Injector instanceof Symbolic) {
-                Injector = Injector.Ctr;
+            if (Symbolic.isSymbolic(Injector)) {
+                Injector = FACTORY_SYMBOLS[Injector];
             }
             if (!this[Injector.SYM]) {
                 if (ctx) {
@@ -326,7 +328,7 @@ export const InjectableMixin = (SuperClass) => class extends mix(SuperClass).wit
      */
     destroy() {
         this.inject.forEach((Injector) => {
-            let SYM = (Injector instanceof Symbolic) ? Injector : Injector.SYM;
+            let SYM = (Symbolic.isSymbolic(Injector)) ? Injector : Injector.SYM;
             delete this[SYM];
         });
         return super.destroy();

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,6 +1,6 @@
 import Symbolic from './symbolic.js';
 
-const MIXINS_SYM = new Symbolic('mixins');
+const MIXINS_SYM = Symbolic('mixins');
 
 /**
  * Mix a class with a mixin.

--- a/src/observable.js
+++ b/src/observable.js
@@ -56,6 +56,7 @@ const ProxyHelper = typeof Proxy !== 'undefined' ? Proxy : class {
                 }
             });
         }
+        res[OBSERVABLE_SYM] = data[OBSERVABLE_SYM];
         return res;
     }
 

--- a/src/symbolic.js
+++ b/src/symbolic.js
@@ -9,10 +9,10 @@ const registry = [];
 /**
  * Polyfill for Symbol.
  *
- * @class Symbolic
+ * @class SymbolPolyfill
  * @param {string} property The Symbol name.
  */
-class Symbolic {
+class SymbolPolyfill {
     constructor(property) {
         let sym = this.SYM = `__${property}_${registry.length}`;
         registry.push(sym);
@@ -41,12 +41,14 @@ class Symbolic {
  * @param {string} property The Symbol name.
  * @return {Symbol|Symbolic}
  */
-export default function SymbolicFactory(property) {
+export default function Symbolic(property) {
     if (support) {
         // native Symbol support.
-        return Symbol(property);
+        let sym = Symbol(property);
+        registry.push(sym);
+        return sym;
     }
-    return new Symbolic(property);
+    return new SymbolPolyfill(property);
 }
 
 /**
@@ -54,13 +56,9 @@ export default function SymbolicFactory(property) {
  * @param {Symbol|Symbolic} sym The symbol to check.
  * @return {Boolean}
  */
-SymbolicFactory.isSymbolic = function(sym) {
-    if (sym instanceof Symbolic) {
+Symbolic.isSymbolic = function(sym) {
+    if (sym instanceof SymbolPolyfill) {
         return true;
     }
-    return sym && (
-        support ?
-            (sym.constructor === Symbol) :
-            (registry.indexOf(sym) !== -1)
-    );
+    return sym && (support && registry.indexOf(sym) !== -1);
 };

--- a/src/symbolic.js
+++ b/src/symbolic.js
@@ -1,4 +1,3 @@
-let count = 0;
 let support = (() => {
     try {
         if (typeof Symbol === 'function') {
@@ -18,48 +17,67 @@ let support = (() => {
     return false;
 })();
 
+/**
+ * Polyfill registry for symbols.
+ * @type {Array}
+ */
 const registry = [];
 
 /**
- * Create a symbolic key for objects's properties.
+ * Polyfill for Symbol.
  *
  * @class Symbolic
- * @param {string} property The Symbol name
+ * @param {string} property The Symbol name.
  */
-export default class Symbolic {
-    static isSymbolic(sym) {
-        if (sym instanceof Symbolic) {
-            return true;
-        }
-        return sym && (
-            support ?
-                (sym.constructor === Symbol) :
-                (registry.indexOf(sym) !== -1)
-        );
-    }
-
+class Symbolic {
     constructor(property) {
-        if (support) {
-            this.SYM = Symbol(property);
-        } else {
-            let sym = this.SYM = `__${property}_${count++}`;
-            registry.push(sym);
-            Object.defineProperty(Object.prototype, sym, {
-                configurable: true,
-                enumerable: false,
-                set(x) {
-                    Object.defineProperty(this, sym, {
-                        configurable: true,
-                        enumerable: false,
-                        writable: true,
-                        value: x,
-                    });
-                },
-            });
-        }
+        let sym = this.SYM = `__${property}_${registry.length}`;
+        registry.push(sym);
+        Object.defineProperty(Object.prototype, sym, {
+            configurable: true,
+            enumerable: false,
+            set(x) {
+                Object.defineProperty(this, sym, {
+                    configurable: true,
+                    enumerable: false,
+                    writable: true,
+                    value: x,
+                });
+            },
+        });
     }
 
     toString() {
         return this.SYM;
     }
 }
+
+/**
+ * Create a symbolic key for objects's properties.
+ *
+ * @param {string} property The Symbol name.
+ * @return {Symbol|Symbolic}
+ */
+export default function SymbolicFactory(property) {
+    if (support) {
+        // native Symbol support.
+        return Symbol(property);
+    }
+    return Symbolic(property);
+}
+
+/**
+ * Check if an instance is a Symbol.
+ * @param {Symbol|Symbolic} sym The symbol to check.
+ * @return {Boolean}
+ */
+SymbolicFactory.isSymbolic = function(sym) {
+    if (sym instanceof Symbolic) {
+        return true;
+    }
+    return sym && (
+        support ?
+            (sym.constructor === Symbol) :
+            (registry.indexOf(sym) !== -1)
+    );
+};

--- a/src/symbolic.js
+++ b/src/symbolic.js
@@ -1,21 +1,4 @@
-let support = (() => {
-    try {
-        if (typeof Symbol === 'function') {
-            class Test {
-                toString() {
-                    return Symbol();
-                }
-            }
-            new Object({
-                [new Test()]: 0,
-            });
-            return true;
-        }
-    } catch (ex) {
-        //
-    }
-    return false;
-})();
+const support = (typeof Symbol === 'function');
 
 /**
  * Polyfill registry for symbols.

--- a/src/symbolic.js
+++ b/src/symbolic.js
@@ -46,7 +46,7 @@ export default function SymbolicFactory(property) {
         // native Symbol support.
         return Symbol(property);
     }
-    return Symbolic(property);
+    return new Symbolic(property);
 }
 
 /**

--- a/src/url.js
+++ b/src/url.js
@@ -5,7 +5,7 @@
 import * as keypath from './keypath.js';
 import Symbolic from './symbolic.js';
 
-const REF_SYM = new Symbolic('ref');
+const REF_SYM = Symbolic('ref');
 const URL_REGEX = /((?:^(?:[a-z]+:))|^)?(?:\/\/)?([^?/$]*)([^?]*)?(\?.*)?/i;
 const PORT_REGEX = /:\d*$/;
 

--- a/test/observable.spec.js
+++ b/test/observable.spec.js
@@ -84,7 +84,8 @@ describe('Unit: Observable', () => {
     });
 
     describe('complex objects', () => {
-        let changes = [];
+        let changes1 = [];
+        let changes2 = [];
         let observable = new Observable({
             prop1: 1,
             prop2: ['a', 'b'],
@@ -97,9 +98,14 @@ describe('Unit: Observable', () => {
                 { prop4_2: [] },
             ],
         });
+        let observable2 = new Observable(observable);
 
         observable.on('change', (changset) => {
-            changes.push(changset);
+            changes1.push(changset);
+        });
+
+        observable2.on('change', (changset) => {
+            changes2.push(changset);
         });
 
         it('should trigger changes', () => {
@@ -113,11 +119,12 @@ describe('Unit: Observable', () => {
             });
             observable.prop4[1].prop4_2[0].prop6 = 10;
 
-            assert.equal(changes.length, 7);
+            assert.equal(changes1.length, 7);
+            assert.deepEqual(changes1, changes2);
         });
 
         it('should compute property name', () => {
-            let paths = changes.map((change) => change.property);
+            let paths = changes1.map((change) => change.property);
             assert.deepEqual(paths, [
                 'prop1',
                 'prop2.2',
@@ -132,7 +139,7 @@ describe('Unit: Observable', () => {
 
     describe('symbolic keys', () => {
         let changes = [];
-        let sym = new Symbolic('tags');
+        let sym = Symbolic('tags');
         let observable = new Observable({
             name: 'Alan',
             [sym]: ['math'],
@@ -156,6 +163,18 @@ describe('Unit: Observable', () => {
             assert.throws(() => new Observable('hello'));
             assert.throws(() => new Observable(undefined));
             assert.throws(() => new Observable(NaN));
+        });
+    });
+
+    describe('Observable object with thousands of instances', () => {
+        it('should not crash in Firefox', () => {
+            assert.doesNotThrow(() => {
+                let obj = [[], [], [], [], [], [], [], [], []];
+                let obs = new Observable(obj);
+                for (let i = 0; i < 3000; i++) {
+                    obs = new Observable(obs);
+                }
+            });
         });
     });
 });

--- a/test/symbolic.spec.js
+++ b/test/symbolic.spec.js
@@ -3,7 +3,7 @@ import Symbolic from '../src/symbolic.js';
 
 describe('Unit: Symbolic', () => {
     it('should set a symbolic property', () => {
-        const AGE = new Symbolic('age');
+        const AGE = Symbolic('age');
         let user = {
             firstName: 'Alan',
             lastName: 'Turing',


### PR DESCRIPTION
Now the Symbolic function returns a real Symbol instance (if `Symbol` is supported) or a polyfilled instance.

**Note** that `new Symbolic` calls are no more not supported. Just call `Symbolic` as a function.