### PR TITLE
fix: keypath.has() now works with event objects

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -142,22 +142,11 @@ export function has(obj, path) {
     assertArgs(obj, path);
     path = pathToArray(path);
     let current = path.shift();
-    if (isObject(obj)) {
-        if (obj.hasOwnProperty(current)) {
-            if (path.length === 0) {
-                return true;
-            }
-            return has(obj[current], path);
+    if (current in obj) {
+        if (path.length === 0) {
+            return true;
         }
-    }
-    if (isArray(obj) && !isNaN(current)) {
-        current = parseInt(current);
-        if (obj.length > current) {
-            if (path.length === 0) {
-                return true;
-            }
-            return has(obj[current], path);
-        }
+        return has(obj[current], path);
     }
     return false;
 }

--- a/src/keypath.js
+++ b/src/keypath.js
@@ -142,6 +142,15 @@ export function has(obj, path) {
     assertArgs(obj, path);
     path = pathToArray(path);
     let current = path.shift();
+    if (isArray(obj) && !isNaN(current)) {
+        current = parseInt(current);
+        if (obj.length > current) {
+            if (path.length === 0) {
+                return true;
+            }
+            return has(obj[current], path);
+        }
+    }
     if (current in obj) {
         if (path.length === 0) {
             return true;

--- a/src/keypath.js
+++ b/src/keypath.js
@@ -28,7 +28,7 @@ function assertObject(obj) {
  *
  * @param {*} obj The object to check
  * @param {*} path The property path
- * @return {boolean} Arguments valid or not
+ * @return {void}
  * @throws {Error} throw error when object scope is invalid undefined
  * @throws {Error} throw error when paths is invalid or undefined
  */
@@ -73,16 +73,15 @@ function pathToArray(path) {
  */
 export function get(obj, path) {
     assertArgs(obj, path);
-    path = pathToArray(path);
-    let current = path.shift();
-    let currentObj = obj[current];
-    if (path.length === 0) {
-        return currentObj;
-    }
-    if (!assertObject(currentObj)) {
+    if (!has(obj, path)) {
         return undefined;
     }
-    return get(currentObj, path);
+    let value = obj;
+    path = pathToArray(path);
+    path.forEach(prop => {
+        value = value[prop];
+    });
+    return value;
 }
 
 /**

--- a/test/keypath.spec.js
+++ b/test/keypath.spec.js
@@ -363,6 +363,12 @@ describe('Unit: Keypath', () => {
             assert(!keypath.has(obj, 'b.4'));
         });
 
+        it('should work with properties manually added to an array', () => {
+            let arr = [];
+            arr['property'] = 'new property';
+            assert(keypath.has(arr, 'property'));
+        });
+
         it('should test the value under array deep', () => {
             let obj = getTestObj();
             assert(keypath.has(obj, 'b.e.1.f'));


### PR DESCRIPTION
This PR solves this two Issues:
* [https://github.com/Chialab/proteins/issues/7](url)
* [https://github.com/Chialab/proteins/issues/8](url)

Also refactored `get` method using  new version of `has` method.