### PR TITLE
feat: changed object check in observable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       node_js: 8
       install:
         - npm install
-        - npm install karma-sauce-launcher
+        - npm install github:edoardocavazza/karma-sauce-launcher
       script:
         - npm run test-saucelabs
     - stage: test

--- a/sauce.browsers.js
+++ b/sauce.browsers.js
@@ -90,7 +90,6 @@ module.exports = {
         platform: 'macOS 10.12',
         version: '10.1',
     },
-
     /** IE/EDGE */
     SL_IE_11: {
         base: 'SauceLabs',
@@ -141,6 +140,14 @@ module.exports = {
         version: '10.3',
         appiumVersion: '1.7.1',
         device: 'iPhone 7',
+    },
+    SL_iOS_10_2: {
+        base: 'SauceLabs',
+        browserName: 'Safari',
+        platform: 'iOS',
+        version: '10.2',
+        appiumVersion: '1.7.1',
+        device: 'iPhone 5',
     },
     SL_iOS_11: {
         base: 'SauceLabs',

--- a/sauce.browsers.js
+++ b/sauce.browsers.js
@@ -43,13 +43,13 @@ module.exports = {
     SL_Firefox_dev: {
         base: 'SauceLabs',
         browserName: 'firefox',
-        platform: 'macOS 10.12',
+        platform: 'Windows 10',
         version: 'dev',
     },
     SL_Firefox_beta: {
         base: 'SauceLabs',
         browserName: 'firefox',
-        platform: 'macOS 10.12',
+        platform: 'Windows 10',
         version: 'beta',
     },
     SL_Firefox: {

--- a/src/observable.js
+++ b/src/observable.js
@@ -213,7 +213,7 @@ const handler = {
  */
 export default class Observable {
     constructor(data) {
-        if (!isObject(data) && !isArray(data)) {
+        if (typeof data !== 'object') {
             throw new Error('Cannot observe this value.');
         }
 

--- a/test/observable.spec.js
+++ b/test/observable.spec.js
@@ -168,6 +168,12 @@ describe('Unit: Observable', () => {
         });
     });
 
+    describe('Observable of observable objects', () => {
+        it('should handle observable of observable', () => {
+            assert.doesNotThrow(() => new Observable(new Observable({})));
+        });
+    });
+
     describe('Observable object with thousands of instances', () => {
         it('should not crash in Firefox', () => {
             assert.doesNotThrow(() => {


### PR DESCRIPTION
Problem: on `iOS 10.2.0` 

```
var a = new Proxy({}, {});
console.log(a.toString());  // '[object ProxyObject]'
```
instead of print `[object Object]`. This lead to problems on `Observable' of `proteins`. 
We decide to handle this very special case modifying object checking in `Observable` (in iOS 11.* or versions before 10.2.0 it instead behaves as expected).