### PR TITLE
Issue/#17 clone array properties

### DIFF
--- a/src/clone.js
+++ b/src/clone.js
@@ -34,8 +34,6 @@ export default function clone(obj, callback = noop, cache = new WeakMap()) {
         }
         for (let key in descriptors) {
             const desc = descriptors[key];
-            let clonedVal = clone(obj[key], callback, cache);
-            let val = callback(obj, key, clonedVal);
             let newDescriptor = {
                 configurable: true,
                 enumerable: desc.enumerable,
@@ -45,7 +43,8 @@ export default function clone(obj, callback = noop, cache = new WeakMap()) {
                 newDescriptor['set'] = desc.set;
             } else {
                 // `value` and `writable` are allowed in a descriptor only when there isn't a getter/setter.
-                newDescriptor['value'] = val;
+                let clonedVal = clone(desc.value, callback, cache);
+                newDescriptor['value'] = callback(obj, key, clonedVal);
                 newDescriptor['writable'] = desc.writable;
             }
             Object.defineProperty(res, key, newDescriptor);

--- a/src/clone.js
+++ b/src/clone.js
@@ -17,26 +17,39 @@ function noop(scope, key, prop) { return prop; }
  * @method clone
  * @param {*} obj The instance to clone.
  * @param {Function} [callback] A modifier function for each property.
- * @param {Array} [cache] The cache array for circular references.
+ * @param {WeakMap} [cache] The cache for circular references.
  * @return {*} The clone of the object.
  */
-export default function clone(obj, callback = noop, cache = []) {
-    if (isArray(obj)) {
-        return obj.map((entry, index) => {
-            entry = callback(obj, index, entry);
-            return clone(entry, callback, cache);
-        });
-    } else if (isObject(obj)) {
-        let cached = cache.indexOf(obj);
-        if (cached !== -1) {
-            return cache[cached + 1];
+export default function clone(obj, callback = noop, cache = new WeakMap()) {
+    if (isObject(obj) || isArray(obj)) {
+        if (cache.has(obj)) {
+            return cache.get(obj);
         }
         let res = reconstruct(get(obj));
-        cache.push(obj, res);
-        Object.keys(obj).forEach((k) => {
-            let val = callback(obj, k, obj[k]);
-            res[k] = clone(val, callback, cache);
-        });
+        cache.set(obj, res);
+        const descriptors = Object.getOwnPropertyDescriptors(obj);
+        if (isArray(obj)) {
+            // do not redefine `length` property.
+            delete descriptors['length'];
+        }
+        for (let key in descriptors) {
+            const desc = descriptors[key];
+            let clonedVal = clone(obj[key], callback, cache);
+            let val = callback(obj, key, clonedVal);
+            let newDescriptor = {
+                configurable: true,
+                enumerable: desc.enumerable,
+            };
+            if (desc.get || desc.set) {
+                newDescriptor['get'] = desc.get;
+                newDescriptor['set'] = desc.set;
+            } else {
+                // `value` and `writable` are allowed in a descriptor only when there isn't a getter/setter.
+                newDescriptor['value'] = val;
+                newDescriptor['writable'] = desc.writable;
+            }
+            Object.defineProperty(res, key, newDescriptor);
+        }
         return res;
     } else if (isDate(obj)) {
         return new Date(obj.getTime());

--- a/test/clone.spec.js
+++ b/test/clone.spec.js
@@ -63,7 +63,7 @@ describe('Unit: Clone', () => {
     it('should clone an object with custom callback', () => {
         let original = [1, 2, 3];
         let cloned = clone(original, (arr, index, val) => {
-            if (index === 1) {
+            if (index == 1) {
                 return 2 * val;
             }
             return val;
@@ -121,5 +121,32 @@ describe('Unit: Clone', () => {
         const TEST_FUN = () => { };
         assert.equal(clone(TEST_FUN), TEST_FUN);
         assert(clone(TEST_FUN) !== TEST_FUN.bind(null));
+    });
+
+    it('should clone properties with getter/setter', () => {
+        const a = {
+            test: 2,
+        };
+        Object.defineProperty(a, 'test2', {
+            get() {
+                return this.test;
+            },
+            set(val) {
+                this.test = this.test * val;
+            },
+        });
+        let cloned = clone(a);
+        assert.equal(cloned.test, 2);
+        assert.equal(cloned.test2, 2);
+
+        cloned.test2 = 3;
+        assert.equal(cloned.test, 6);
+    });
+
+    it('should clone arrays with custom properties', () => {
+        const a = [1, 2];
+        Object.defineProperty(a, 'test', { value: 3 });
+        let cloned = clone(a);
+        assert.equal(cloned.test, 3);
     });
 });


### PR DESCRIPTION
Closes #17 

Custom properties, getters and setters are now cloned. The new implementation uses **descriptors** instead of classic value access.