### PR TITLE
Prototype of observable arrays should be an array

### DIFF
--- a/src/clone.js
+++ b/src/clone.js
@@ -31,15 +31,15 @@ export default function clone(obj, callback = noop, useStrict = false, cache = n
         if (cache.has(obj)) {
             return cache.get(obj);
         }
-        let res = reconstruct(get(obj));
+        const res = reconstruct(get(obj));
         cache.set(obj, res);
+        const newDescriptors = getDescriptors(res);
         const descriptors = getDescriptors(obj);
-        if (isArray(obj)) {
-            // do not redefine `length` property.
-            delete descriptors.length;
-        }
         for (let key in descriptors) {
             const descriptor = descriptors[key];
+            if (newDescriptors[key] && !newDescriptors[key].configurable) {
+                continue;
+            }
             let value;
             if ('value' in descriptor) {
                 value = callback(obj, key, clone(descriptor.value, callback, useStrict, cache));

--- a/src/observable.js
+++ b/src/observable.js
@@ -179,6 +179,12 @@ function subobserve(target, name, value) {
  * @private
  */
 const handler = {
+    getPrototypeOf(target) {
+        if (Array.isArray(target)) {
+            return target.constructor.prototype;
+        }
+        return Reflect.getPrototypeOf(target);
+    },
     get: (target, name) => target[name],
     set: (target, name, value) => {
         if (Symbolic.isSymbolic(name)) {

--- a/src/proto.js
+++ b/src/proto.js
@@ -2,7 +2,7 @@
  * @module Proto
  */
 
-import { isFunction, isObject } from './types.js';
+import { isFunction, isObject, isArray } from './types.js';
 import hasOwnProperty from './has.js';
 
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
@@ -161,8 +161,10 @@ export function extend(proto1, proto2) {
 export function reconstruct(Ctr) {
     if (isFunction(Ctr)) {
         return reconstruct(Ctr.prototype);
-    } else if (Ctr === Array.prototype) {
-        return [];
+    } else if (isArray(Ctr)) {
+        const res = [];
+        set(res, Ctr);
+        return res;
     }
     return create(Ctr);
 }

--- a/src/proto.js
+++ b/src/proto.js
@@ -104,24 +104,24 @@ export function has(Ctr, property) {
  * Retrieve prototype of an object.
  * @memberof Proto
  *
- * @param {Object} Ctr The object to analyze.
+ * @param {Object} obj The object to analyze.
  * @return {Object} The prototype.
  */
-export function get(Ctr) {
+export function get(obj) {
     if (Object.getPrototypeOf) {
-        return Object.getPrototypeOf(Ctr);
+        return Object.getPrototypeOf(obj);
     }
-    if (isObject(Ctr.__proto__)) {
-        return Ctr.__proto__;
+    if (isObject(obj.__proto__)) {
+        return obj.__proto__;
     }
-    return Ctr.constructor.prototype;
+    return obj.constructor.prototype;
 }
 
 /**
  * Set prototype to an object.
  * @memberof Proto
  *
- * @param {Object} Ctr The object to update.
+ * @param {Object} obj The object to update.
  * @param {Object|Function} proto The prototype or the class to use.
  */
 export function set(obj, proto) {
@@ -160,7 +160,7 @@ export function extend(proto1, proto2) {
  */
 export function reconstruct(Ctr) {
     if (isFunction(Ctr)) {
-        return create(Ctr.prototype);
+        return reconstruct(Ctr.prototype);
     } else if (Ctr === Array.prototype) {
         return [];
     }

--- a/test/clone.spec.js
+++ b/test/clone.spec.js
@@ -204,10 +204,10 @@ describe('Unit: Clone', () => {
         // }, TypeError);
     });
 
-    it.only('should clone Observable arrays', () => {
+    it('should clone Observable arrays', () => {
         const a = new Observable([1, 2]);
         const cloned = clone(a);
-        assert(Array.isArray(cloned));
+        assert(isArray(cloned));
         assert.notStrictEqual(cloned, [1, 2]);
     });
 });

--- a/test/clone.spec.js
+++ b/test/clone.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import clone from '../src/clone.js';
 import { isDate, isNumber, isString, isObject, isArray, isUndefined } from '../src/types.js';
+import Observable from '../src/observable.js';
 import chai from 'chai/chai';
 
 const { assert } = chai;
@@ -148,5 +149,12 @@ describe('Unit: Clone', () => {
         Object.defineProperty(a, 'test', { value: 3 });
         let cloned = clone(a);
         assert.equal(cloned.test, 3);
+    });
+
+    it.only('should clone Observable arrays', () => {
+        const a = new Observable([1, 2]);
+        const cloned = clone(a);
+        assert(Array.isArray(cloned));
+        assert.notStrictEqual(cloned, [1, 2]);
     });
 });

--- a/test/observable.spec.js
+++ b/test/observable.spec.js
@@ -129,6 +129,10 @@ describe('Unit: Observable', () => {
         it('should trigger changes', () => {
             assert.equal(changes.length, 4);
         });
+
+        it('should be of type Array', () => {
+            assert(Array.isArray(observable));
+        });
     });
 
     describe('complex objects', () => {


### PR DESCRIPTION
fixes #16

Added the `getPrototypeOf ` trap for proxied arrays.