### PR TITLE
Add default value to keypath.get()

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -70,14 +70,15 @@ function pathToArray(path) {
  *
  * @param {Object} obj The object scope
  * @param {String|Array} path The path of the property to retrieve
+ * @param {mixed} defaultValue The default value returned if path was not found. Default is undefined.
  * @return {*} The property value
  * @throws {Error} throw error when object scope is undefined
  * @throws {Error} throw error when paths is invalid or undefined
  */
-export function get(obj, path) {
+export function get(obj, path, defaultValue) {
     assertArgs(obj, path);
     if (!has(obj, path)) {
-        return undefined;
+        return defaultValue;
     }
     let value = obj;
     path = pathToArray(path);

--- a/src/keypath.js
+++ b/src/keypath.js
@@ -70,7 +70,7 @@ function pathToArray(path) {
  *
  * @param {Object} obj The object scope
  * @param {String|Array} path The path of the property to retrieve
- * @param {mixed} defaultValue The default value returned if path was not found. Default is undefined.
+ * @param {*} defaultValue The default value returned if path was not found. Default is undefined.
  * @return {*} The property value
  * @throws {Error} throw error when object scope is undefined
  * @throws {Error} throw error when paths is invalid or undefined

--- a/test/keypath.spec.js
+++ b/test/keypath.spec.js
@@ -101,6 +101,23 @@ describe('Unit: Keypath', () => {
             assert.equal(keypath.get(obj, '1a'), 'foo');
             assert.equal(keypath.get(obj, ['1a']), 'foo');
         });
+
+        it('should return default value passed for missing values under object', () => {
+            let obj = getTestObj();
+            assert.isFalse(keypath.get(obj, 'a.b', false));
+            assert.isTrue(keypath.get(obj, 'a.b', true));
+            assert.isNull(keypath.get(obj, 'a.b', null));
+
+            let expected = [];
+            assert.deepEqual(keypath.get(obj, 'a.b', []), expected);
+
+            expected = {
+                a: {
+                    b: true,
+                },
+            };
+            assert.deepEqual(keypath.get(obj, 'a.b', expected), expected);
+        });
     });
 
     describe('set', () => {


### PR DESCRIPTION
This PR add the ability to `keypath.get()` to pass a default value to return in case the path searched was not found.

```js
const el = keypath.get(obj, 'missing.path', false);
// console.log(el) => false

const el = keypath.get(obj, 'missing.path', {name: 'Gustavo'});
// console.log(el) => {name: 'Gustavo'}
```