### PR TITLE
Promises pool

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import * as Url from './url.js';
 
 export * from './types.js';
 export * from './events.js';
+export * from './pool.js';
 export { has };
 export { Symbolic };
 export { Observable };

--- a/src/pool.js
+++ b/src/pool.js
@@ -1,0 +1,53 @@
+/**
+ * Execute a bunch of promises in parallel limiting the number of parallel pending promises.
+ *
+ * @param {number} workers Number of parallel workers.
+ * @param {(() => Promise<T>)[]} promiseFactories List of promise factories.
+ * @returns {Promise<T[]>}
+ * @template T
+ */
+export function pool(workers, promiseFactories) {
+    if (workers < 1) {
+        throw new Error('Number of workers must be positive');
+    }
+
+    const results = Array(promiseFactories.length);
+    const iterator = arrayIterator(promiseFactories);
+    const dequeuer = () => {
+        const next = iterator.next();
+        if (next.done) {
+            return Promise.resolve();
+        }
+
+        const { index, value } = next.value;
+
+        return value()
+            .then((res) => {
+                results[index] = res;
+
+                return dequeuer();
+            });
+    };
+
+    const promises = [];
+    for (let i = 0; i < workers; i++) {
+        promises.push(dequeuer());
+    }
+
+    return Promise.all(promises)
+        .then(() => results);
+};
+
+/**
+ * Iterate over an array and keep track of the current index.
+ *
+ * @param {T[]} arr Array to iterate over.
+ * @returns {Generator<{index: number, value: T}>}
+ * @template T
+ */
+function* arrayIterator(arr) {
+    for (let index = 0; index < arr.length; index++) {
+        const value = arr[index];
+        yield { index, value };
+    }
+}

--- a/src/pool.js
+++ b/src/pool.js
@@ -19,8 +19,8 @@ export function pool(workers, promiseFactories) {
 
     return Promise.all(promises)
         .then((results) => results
-            .reduce((results, workerResults) => results.concat(workerResults))
-            .sort(({ index: a }, { index: b }) => a - b)
+            .flat()
+            .sort((a, b) => a.index - b.index)
             .map(({ result }) => result)
         );
 }

--- a/src/pool.js
+++ b/src/pool.js
@@ -36,7 +36,7 @@ export function pool(workers, promiseFactories) {
 
     return Promise.all(promises)
         .then(() => results);
-};
+}
 
 /**
  * Iterate over an array and keep track of the current index.

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -33,6 +33,23 @@ describe('Unit: Pool', () => {
         });
     });
 
+    it('should return results in the correct order when input is a generator', () => {
+        const factory = (sleep, returnVal) => () => new Promise((resolve) => {
+            setTimeout(() => resolve(returnVal), sleep);
+        });
+        const tasks = function* () {
+            yield factory(10, 1);
+            yield factory(20, 2);
+            yield factory(1, 3);
+            yield factory(5, 4);
+            yield factory(1, 5);
+        }();
+
+        return pool(2, tasks).then((res) => {
+            assert.deepEqual(res, [1, 2, 3, 4, 5]);
+        });
+    });
+
     it('should reject when a promise rejects', () => {
         let bitmask = 0;
         const factory = (sleep, bit) => () => new Promise((resolve) => {

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -60,11 +60,11 @@ describe('Unit: Pool', () => {
         });
         const tasks = [
             factory(20, 1),
-            factory(5, 2),
-            factory(1, 4),
+            factory(5, 1),
+            factory(1, 1),
             () => Promise.reject('foo'),
-            factory(10, 8),
-            factory(20, 16),
+            factory(10, 2),
+            factory(20, 2),
             () => Promise.reject('bar'),
         ];
 
@@ -73,7 +73,7 @@ describe('Unit: Pool', () => {
                 () => assert.fail('should have rejected'),
                 (err) => {
                     assert.equal(err, 'foo');
-                    assert.equal(bitmask, 6);
+                    assert.equal(bitmask, 1);
                 }
             );
     });

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -1,0 +1,99 @@
+import { pool } from '../src/index.js';
+import { assert } from '@esm-bundle/chai/esm/chai.js';
+
+describe('Unit: Pool', () => {
+    it('should run all promises', () => {
+        let bitmask = 0;
+        const tasks = [
+            async () => { bitmask |= 1; },
+            async () => { bitmask |= 2; },
+            async () => { bitmask |= 4; },
+            async () => { bitmask |= 8; },
+        ];
+
+        return pool(2, tasks).then(() => {
+            assert.equal(bitmask, 15);
+        });
+    });
+
+    it('should return results in the correct order', () => {
+        const factory = (sleep, returnVal) => () => new Promise((resolve) => {
+            setTimeout(() => resolve(returnVal), sleep);
+        });
+        const tasks = [
+            factory(10, 1),
+            factory(20, 2),
+            factory(1, 3),
+            factory(5, 4),
+            factory(1, 5),
+        ];
+
+        return pool(2, tasks).then((res) => {
+            assert.deepEqual(res, [1, 2, 3, 4, 5]);
+        });
+    });
+
+    it('should reject when a promise rejects', () => {
+        let bitmask = 0;
+        const factory = (sleep, bit) => () => new Promise((resolve) => {
+            setTimeout(() => {
+                bitmask |= bit;
+                resolve();
+            }, sleep);
+        });
+        const tasks = [
+            factory(20, 1),
+            factory(5, 2),
+            factory(1, 4),
+            () => Promise.reject('foo'),
+            factory(10, 8),
+            factory(20, 16),
+            () => Promise.reject('bar'),
+        ];
+
+        return pool(2, tasks)
+            .then(
+                () => assert.fail('should have rejected'),
+                (err) => {
+                    assert.equal(err, 'foo');
+                    assert.equal(bitmask, 6);
+                }
+            );
+    });
+
+    it('should have at most one concurrent task per worker', () => {
+        let current = 0;
+        let max = 0;
+        const factory = (sleep) => () => new Promise((resolve) => {
+            current++;
+            max = Math.max(max, current);
+            setTimeout(() => {
+                max = Math.max(max, current);
+                resolve();
+                current--;
+            }, sleep);
+        });
+        const tasks = [
+            factory(10),
+            factory(5),
+            factory(1),
+            factory(5),
+            factory(10),
+            factory(5),
+            factory(1),
+            factory(2),
+            factory(5),
+        ];
+
+        return pool(3, tasks).then(() => {
+            assert.equal(current, 0);
+            assert.equal(max, 3);
+        });
+    });
+
+    it('should throw when number of workers is less than one', () => {
+        assert.throws(() => {
+            pool(0, []);
+        }, 'Number of workers must be positive');
+    });
+});

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -2,6 +2,13 @@ import { pool } from '../src/index.js';
 import { assert } from '@esm-bundle/chai/esm/chai.js';
 
 describe('Unit: Pool', () => {
+    it('should return empty array when there are no tasks to run', () => {
+        const tasks = [];
+        return pool(2, tasks).then((res) => {
+            assert.deepEqual(res, []);
+        });
+    });
+
     it('should run all promises', () => {
         let bitmask = 0;
         const tasks = [
@@ -30,6 +37,21 @@ describe('Unit: Pool', () => {
 
         return pool(2, tasks).then((res) => {
             assert.deepEqual(res, [1, 2, 3, 4, 5]);
+        });
+    });
+
+    it('should return results in the correct order when number of promises is less than number of workers', () => {
+        const factory = (sleep, returnVal) => () => new Promise((resolve) => {
+            setTimeout(() => resolve(returnVal), sleep);
+        });
+        const tasks = [
+            factory(10, 1),
+            factory(5, 2),
+            factory(1, 3),
+        ];
+
+        return pool(5, tasks).then((res) => {
+            assert.deepEqual(res, [1, 2, 3]);
         });
     });
 


### PR DESCRIPTION
This PR adds a helper function to maintain a pool of at most the desired number of parallel workers, and wait for all promises to complete.

## Usage

```js
import { pool } from '@chialab/proteins';

// Note how this is an higher order function!
const fetchPageBuilder = (page) => () => fetch(`/posts?page=${page}`)
  .then((res) => res.json());

const pagesDfd = [];
for (let p = 1; p <= numPages; p++) ){
  pagesDfd.push(fetchPageBuilder(i));
}

// Fetch all pages, but have no more than 5 pending requests at any given time.
const pages = await pool(5, pagesDfd);
```

Any iterable is also supported. The previous example can be rewritten in a slightly more concise and memory-efficient fashion with a generator:

```js
import { pool } from '@chialab/proteins';

const gen = function* (numPages) {
  for (let p = 1; p <= numPages; p++) ){
    // Note how we're yielding a function here, not the actual promise!
    yield () => fetch(`/posts?page=${p}`).then((res) => res.json());
  }
}(numPages);

// Fetch all pages, but have no more than 5 pending requests at any given time.
const pages = await pool(5, gen);